### PR TITLE
Fix policy type

### DIFF
--- a/src/policies/enforce-user-annotations/policy.yaml
+++ b/src/policies/enforce-user-annotations/policy.yaml
@@ -6,4 +6,4 @@ spec:
   operations: [CREATE, UPDATE]
   resources: ["*"]
   scope: Namespaced
-  mutating: true
+  type: Mutating


### PR DESCRIPTION
A fix proposal to https://github.com/loft-sh/jspolicy-sdk/issues/7

Kubectl throws errors when trying to apply this policy `policies/enforce-user-annotations.yaml` build with the SDK:

```
jspolicybundle.policy.jspolicy.com/enforce-user-annotations.mycompany.tld created
jspolicybundle.policy.jspolicy.com/validate-deployments.mycompany.tld created
jspolicy.policy.jspolicy.com/validate-deployments.mycompany.tld created
jspolicybundle.policy.jspolicy.com/validate-namespace.mycompany.tld created
jspolicy.policy.jspolicy.com/validate-namespace.mycompany.tld created
jspolicybundle.policy.jspolicy.com/validate-pods.mycompany.tld created
jspolicy.policy.jspolicy.com/validate-pods.mycompany.tld created
error: error validating "policies/enforce-user-annotations.yaml": error validating data: ValidationError(JsPolicy.spec): unknown field "mutating" in com.jspolicy.policy.v1beta1.JsPolicy.spec; if you choose to ignore these errors, turn validation off with --validate=false
```