### PR TITLE
Fix errors array concatenation

### DIFF
--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -1,5 +1,5 @@
 export function denyOnErrors(...errors: Array<string[]>) {
-    const combinedErrors: string[] = [].concat.apply(errors)
+    const combinedErrors: string[] = Array<string>().concat.apply([], errors)
     if (combinedErrors.length > 0) {
         deny("Request denied because of the following errors:\n-" + combinedErrors.join("\n-"));
     }


### PR DESCRIPTION
When no error is present, `combinedErrors` will be equal to `[ [ ] , [ ] , ..... , [ ] ]` (array of empty arrays), and therefore the check for errors with `combinedErrors.length > 0` will always be `true` (`combinedErrors.length` = number of inside arrays) and will trigger the denial of the request.

This PR will fix how error strings are concatenated so that `combinedErrors` will be equal to `[ ]` when no error is present, and `["error 1", "error 2", .... , "error n"]` when errors are present.

the issue is described more here https://github.com/loft-sh/jspolicy-sdk/issues/9